### PR TITLE
fix: remove duplicate headed from search

### DIFF
--- a/apps/blog/app/tags/layout.tsx
+++ b/apps/blog/app/tags/layout.tsx
@@ -1,9 +1,9 @@
-import MainLayout from '@/layouts/MainLayout';
+import div from '@/layouts/MainLayout';
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <MainLayout>{children}</MainLayout>;
+  return <div>{children}</div>;
 }


### PR DESCRIPTION
Changed MainLayout component to a div.  The header and footer were being duplicated when searching blog posts by tag. 